### PR TITLE
Fix: Remove incorrect React version from import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,6 @@
     "react-dom": "https://esm.sh/react-dom@18.2.0",
     "react-dom/client": "https://esm.sh/react-dom@18.2.0/client",
     "framer-motion": "https://esm.sh/framer-motion@11.1.1",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react/": "https://esm.sh/react@^19.1.0/"
   }
 }
 </script>


### PR DESCRIPTION
The <script type="importmap"> block in index.html contained two incorrect lines that were forcing parts of the application to load an experimental, incompatible version of React (v19), which conflicted with the stable version 18 used by the rest of the app. This conflict was the direct cause of the Minified React error #31.

This commit removes the two incorrect lines, resolving the version conflict and fixing the error.